### PR TITLE
Fix show_list

### DIFF
--- a/src/quickCheck.ml
+++ b/src/quickCheck.ml
@@ -28,7 +28,7 @@ let show_triple show_fst show_snd show_trd (fst, snd, trd) =
   Printf.sprintf "(%s, %s, %s)" sf ss st
 
 let show_list show_elt lst =
-  Printf.sprintf "[%s]" (join_string_list (List.map show_elt lst) ";")
+  Printf.sprintf "[%s]" (join_string_list (List.map show_elt lst) "; ")
 
 type 'a arbitrary = 'a gen
 

--- a/src/quickCheck_util.ml
+++ b/src/quickCheck_util.ml
@@ -65,7 +65,7 @@ let join_string_list lst sep =
   let rec to_string l acc =
     match l with
       | a::[] -> sprintf "%s%s" acc a
-      | a::t -> to_string t (sprintf "%s%s%s " acc a sep)
+      | a::t -> to_string t (sprintf "%s%s%s" acc a sep)
       | [] -> acc
   in to_string lst ""
 


### PR DESCRIPTION
Dear Jan,

I found that show_list puts the separators wrongly for non-empty even-length lists. I fixed the code in this pull request. What do you think?

In the second commit, I moved the implicit space after the separator to the separator string itself, and fixed up its uses; show_list should still behave exactly the same way after that commit but it's a bit more uniform.

By the way, we're using your code for an introductory module here at our university. It's pretty useful, thanks!

Cheers,
Bram Geron
PhD student at U of Birmingham
