### PR TITLE
remove -w @a

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -14,8 +14,8 @@ Library quickcheck
   Modules:         QuickCheck,
                    QuickCheck_gen,
                    QuickCheck_util
-  NativeOpt:       -w @a -g
-  ByteOpt:         -w @a -g
+  NativeOpt:       -w @1..49 -g
+  ByteOpt:         -w @1..49 -g
 
 Executable test
   Path: tests/


### PR DESCRIPTION
Using `-w @a` makes your software incompatible with all future OCaml versions. Don't do that.
